### PR TITLE
Fix code scanning alert #6: Failure to use HTTPS or SFTP URL in Maven artifact upload/download

### DIFF
--- a/platforms/software/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/insecureProtocolWarn/some-thing/pom.xml
+++ b/platforms/software/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/insecureProtocolWarn/some-thing/pom.xml
@@ -27,7 +27,7 @@
             <id>local-remote</id>
             <name>Local Test Repository</name>
             <layout>default</layout>
-            <url>http://www.example.com/maven/repo</url>
+            <url>https://www.example.com/maven/repo</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Fixes [https://github.com/aka2024/gradle/security/code-scanning/6](https://github.com/aka2024/gradle/security/code-scanning/6)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
